### PR TITLE
Update covid-19-peru-test-results.csv

### DIFF
--- a/datos/covid-19-peru-test-results.csv
+++ b/datos/covid-19-peru-test-results.csv
@@ -13,8 +13,8 @@ fecha,personas,resultado,tipo_prueba
 2020-04-10,29690,negativo,serológicas
 2020-04-11,5261,positivo,moleculares
 2020-04-11,1587,positivo,serológicas
-2020-04-11,27519,negativo,moleculares
-2020-04-11,38193,negativo,serológicas
+2020-04-11,22258,negativo,moleculares
+2020-04-11,36606,negativo,serológicas
 2020-04-12,5767,positivo,moleculares
 2020-04-12,1752,positivo,serológicas
 2020-04-12,25467,negativo,moleculares


### PR DESCRIPTION
On date 2020-04-11 the data for the negative tests actually corresponds to the total number of tests:

https://www.gob.pe/institucion/minsa/noticias/112163-minsa-casos-confirmados-por-coronavirus-covid-19-ascienden-a-6-848-en-el-peru-comunicado-n-62

This corrects it.