### PR TITLE
Update covid-19-peru-test-results.csv

### DIFF
--- a/datos/covid-19-peru-test-results.csv
+++ b/datos/covid-19-peru-test-results.csv
@@ -434,7 +434,7 @@ fecha,personas,resultado,tipo_prueba
 2020-07-25,103684,positivo,moleculares
 2020-07-25,276200,positivo,serológicas
 2020-07-25,251982,negativo,moleculares
-2020-07-25,1574339,negativo,serológicas
+2020-07-25,1574239,negativo,serológicas
 2020-07-26,NA,positivo,moleculares
 2020-07-26,NA,positivo,serológicas
 2020-07-26,NA,negativo,moleculares


### PR DESCRIPTION
digit mistake:
1574239 instead of 1574339
https://www.gob.pe/institucion/minsa/noticias/215997-minsa-casos-confirmados-por-coronavirus-covid-19-ascienden-a-379-884-en-el-peru-comunicado-n-183